### PR TITLE
anonymization feature working final frontend

### DIFF
--- a/templates/partials/topic/quickreply.tpl
+++ b/templates/partials/topic/quickreply.tpl
@@ -13,6 +13,15 @@
 			<textarea rows="4" name="content" component="topic/quickreply/text" class="form-control mousetrap" placeholder="[[modules:composer.textarea.placeholder]]"></textarea>
 			<div class="imagedrop"><div>[[topic:composer.drag-and-drop-images]]</div></div>
 		</div>
+
+		<!-- Checkbox for Anonymous Posting -->
+			<div class="form-check">
+				<input class="form-check-input" type="checkbox" component="topic/quickreply/anonymousCheckbox">
+				<label class="form-check-label" for="anonymousCheckbox">
+					Submit as Anonymous
+				</label>
+			</div>
+
 		<div>
 			<div class="d-flex justify-content-end gap-2">
 				<button type="submit" component="topic/quickreply/expand" class="btn-ghost-sm border" title="[[topic:open-composer]]"><i class="fa fa-expand"></i></button>


### PR DESCRIPTION
This pull request involves the full frontend logic required to support the new anonymous posting feature. To reiterate, due to the discovery that the UI for full posts is handled by markdown, we pivoted our anonymization feature to only be supported by quickreplies, which is done natively. This code shows the toggle for anonymization on quick replies.