### PR TITLE
Add role tag display to posts

### DIFF
--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -62,6 +62,14 @@
 		<div class="content mt-2 text-break" component="post/content" itemprop="text">
 			{posts.content}
 		</div>
+		 {{{if !posts.isEnglish }}}
+		        <div class="sensitive-content-message">
+		        <a class="btn btn-sm btn-primary view-translated-btn">Click here to view the translated message.</a>
+		        </div>
+		        <div class="translated-content" style="display:none;">
+		        {posts.translatedContent}
+		        </div>
+	        {{{end}}}
 	</div>
 </div>
 

--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -25,7 +25,7 @@
 			</div>
 
 			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
-
+			<span class="badge bg-info text-white ms-2">{posts.user.role}</span>
 			{{{ each posts.user.selectedGroups }}}
 			{{{ if posts.user.selectedGroups.slug }}}
 			<!-- IMPORT partials/groups/badge.tpl -->


### PR DESCRIPTION
Added role tag to posts under topics by adding to posts.tpl. Styled the tag as a badge to match site design.
This correlates to github issues: https://github.com/CMU-313/nodebb-f24-aawaa/issues/21, https://github.com/CMU-313/nodebb-f24-aawaa/issues/22, https://github.com/CMU-313/nodebb-f24-aawaa/issues/23
<img width="268" alt="image" src="https://github.com/user-attachments/assets/a8b03cd8-9221-407a-bcda-b6c65ee91fb0">
