### PR TITLE
Endorsement dropdown feature and badge [Resolves issues #7 #10]

### DIFF
--- a/templates/partials/topic/post-menu-list.tpl
+++ b/templates/partials/topic/post-menu-list.tpl
@@ -22,6 +22,21 @@
 </li>
 {{{ end }}}
 
+<!-- Endorsement compoenent of dropdown starts here -->
+{{{ if posts.endorse }}}
+<li>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/endorse" role="menuitem" href="#">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fas fa-star""></i></span> Un-Endorse
+	</a>
+</li>
+{{{ else }}}
+<li>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/endorse" role="menuitem" href="#">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary far fa-star"></i></span> Endorse
+	</a>
+</li>
+{{{ end }}}
+
 {{{ if posts.display_move_tools }}}
 <li>
 	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/move" role="menuitem" href="#">

--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -54,6 +54,9 @@
 			</div>
 			{{{ end }}}
 			<div class="d-flex align-items-center gap-1 flex-grow-1 justify-content-end">
+				{{{if posts.endorse}}}
+					<span class="menu-icon"><i class="fa fa-fw text-secondary fas fa-star"></i></span>
+				{{{end}}}
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
 				<a href="{config.relative_path}/post/{./pid}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
 			</div>


### PR DESCRIPTION
- Added functional endorsement dropdown to each post
- Pressing the endorse button results in a star badge appearing to the right of the post

Resolves: 
https://github.com/CMU-313/nodebb-f24-aawaa/issues/10
https://github.com/CMU-313/nodebb-f24-aawaa/issues/7

Dropdown button:
<img width="1003" alt="Screenshot 2024-10-10 at 9 53 18 PM" src="https://github.com/user-attachments/assets/7ae17e1d-bc7b-416e-a3f3-25d62c38af7d">

Badge:
<img width="1006" alt="Screenshot 2024-10-10 at 9 53 31 PM" src="https://github.com/user-attachments/assets/1f9f4d56-c781-44a6-9bbc-1abe82f2ea67">
